### PR TITLE
Make entities an iterable for `apply_policies_to_many`

### DIFF
--- a/py_authorization/__init__.py
+++ b/py_authorization/__init__.py
@@ -3,6 +3,7 @@ from .context import Context
 from .policy import Policy, Strategy
 from .policy_strategy import PolicyStrategy
 from .policy_strategy_builder import PolicyStrategyBuilder, StrategyMapper
+from .user import User
 
 __all__ = [
     "Authorization",
@@ -13,4 +14,5 @@ __all__ = [
     "PolicyStrategy",
     "PolicyStrategyBuilder",
     "StrategyMapper",
+    "User",
 ]


### PR DESCRIPTION
This makes the `entities` argument for `apply_policies_to_many` expect an Iterable rather than a list. This allows more flexibility on the type of objects provided to this method. For instance, this now supports SQL Alchemy query objects.

I have additionally fixed some typing issues and exported the `User` dataclass.