### PR TITLE
Revert unintended merge artifacts from or-strategy PR

### DIFF
--- a/py_authorization/__init__.py
+++ b/py_authorization/__init__.py
@@ -5,7 +5,7 @@ __version__ = "2.0.0"
 from .authorization import Authorization, CheckResponse
 from .context import Context
 from .policy import Policy, Strategy
-from .policy_strategy import EmptyEntity, PolicyStrategy
+from .policy_strategy import PolicyStrategy
 from .policy_strategy_builder import PolicyStrategyBuilder, StrategyMapper
 from .user import User
 
@@ -13,7 +13,6 @@ __all__ = [
     "Authorization",
     "CheckResponse",
     "Context",
-    "EmptyEntity",
     "Policy",
     "Strategy",
     "PolicyStrategy",

--- a/py_authorization/authorization.py
+++ b/py_authorization/authorization.py
@@ -9,7 +9,6 @@ from sqlalchemy.orm.query import Query
 
 from .context import Context
 from .policy import Policy, Strategy
-from .policy_strategy import EmptyEntity
 from .policy_strategy_builder import PolicyStrategyBuilder, StrategyMapper
 from .sql_parser import all_entities_in_statement
 from .user import User
@@ -21,6 +20,14 @@ class _ApplicableStrategies(TypedDict):
     strategies: list[Strategy]
     or_strategies: Optional[list[Strategy]]
     context: Context
+
+
+class _EmptyEntity(object):
+    """An empty entity is one that is passed as a fake entity to methods that ask for one but the current permission
+    check doesn't require an entity to run.
+    """
+
+    pass
 
 
 @dataclass
@@ -42,7 +49,9 @@ class Authorization:
         self.logger = logging.getLogger(__name__)
         self.default_action = default_action
         self.policies = policies
-        self.strategy_builder = PolicyStrategyBuilder(strategy_mapper_callable=strategy_mapper_callable)
+        self.strategy_builder = PolicyStrategyBuilder(
+            strategy_mapper_callable=strategy_mapper_callable
+        )
 
     def _get_policy(
         self,
@@ -53,6 +62,7 @@ class Authorization:
     ) -> Optional[Policy]:
         policy: Policy
         for policy in self.policies:
+
             roles = policy.roles
             resources = [r.lower() for r in policy.resources]
             actions = policy.actions
@@ -317,7 +327,9 @@ class Authorization:
         self.logger.debug(f"Policy applied: {policy}")
 
         if policy.deny:
-            self.logger.debug(f"[x] Resource denied by: {policy}, resource: '{resource_to_access}'")
+            self.logger.debug(
+                f"[x] Resource denied by: {policy}, resource: '{resource_to_access}'"
+            )
             return None
 
         context = Context(
@@ -355,6 +367,7 @@ class Authorization:
             resources_to_check = entities.keys() or []
 
         self.logger.debug("Resources from queries")
+        self.logger.debug(resources_to_check)
 
         self.logger.debug(f"Entities to look for policies: {resources_to_check}")
         for resource_to_access in resources_to_check:
@@ -366,13 +379,17 @@ class Authorization:
                 sub_action=sub_action,
             )
             if not policy:
-                self.logger.debug(f"[x] Policy not found, resource: '{resource_to_access}'")
+                self.logger.debug(
+                    f"[x] Policy not found, resource: '{resource_to_access}'"
+                )
                 return query.filter(False)
 
             self.logger.debug(f"Policy applied: {policy}")
 
             if policy.deny:
-                self.logger.debug(f"[x] Resource denied by {policy}, resource: '{resource_to_access}'")
+                self.logger.debug(
+                    f"[x] Resource denied by {policy}, resource: '{resource_to_access}'"
+                )
                 return query.filter(False)
 
             if policy.strategies or policy.or_strategies:
@@ -421,10 +438,14 @@ class Authorization:
             strategy_instance = self.strategy_builder.build(strategy)
             if not strategy_instance:
                 return None
-            processed_entity = strategy_instance.apply_policies_to_entity(processed_entity, context)
+            processed_entity = strategy_instance.apply_policies_to_entity(
+                processed_entity, context
+            )
         return processed_entity
 
-    def _apply_strategies_to_query(self, query: Query, strategies: list[Strategy], context: Context) -> Query:
+    def _apply_strategies_to_query(
+        self, query: Query, strategies: list[Strategy], context: Context
+    ) -> Query:
         for strategy in strategies:
             strategy_instance = self.strategy_builder.build(strategy)
             if not strategy_instance:

--- a/py_authorization/policy_strategy.py
+++ b/py_authorization/policy_strategy.py
@@ -1,32 +1,18 @@
-from __future__ import annotations
-
-from abc import ABC, abstractmethod
-from typing import Any, Generic, TypeVar
+from typing import Any, Optional, TypeVar
 
 from sqlalchemy.orm.query import Query
 
-from .context import Context
-
-
-class EmptyEntity(object):
-    """An empty entity is one that is passed as a fake entity to methods that ask for one but the current permission
-    check doesn't require an entity to run.
-    """
-
-    pass
-
+from py_authorization.context import Context
 
 T = TypeVar("T", bound=object)
 
 
-class PolicyStrategy(ABC, Generic[T]):
+class PolicyStrategy:
     def __init__(self, args: dict[str, Any]) -> None:
         self.args = args
 
-    @abstractmethod
-    def apply_policies_to_entity(self, entity: T | EmptyEntity, context: Context) -> T | None:
+    def apply_policies_to_entity(self, entity: T, context: Context) -> Optional[T]:
         pass
 
-    @abstractmethod
-    def apply_policies_to_query(self, query: Query[T], context: Context) -> Query[T]:
+    def apply_policies_to_query(self, query: Query, context: Context) -> Query:
         pass

--- a/py_authorization/policy_strategy_builder.py
+++ b/py_authorization/policy_strategy_builder.py
@@ -1,18 +1,16 @@
-from __future__ import annotations
-
-from typing import Any, Callable, Type
+from typing import Callable, Optional, Type
 
 from .policy import Strategy
 from .policy_strategy import PolicyStrategy
 
-StrategyMapper = dict[str, Type[PolicyStrategy[Any]]]
+StrategyMapper = dict[str, Type[PolicyStrategy]]
 
 
 class PolicyStrategyBuilder:
     def __init__(self, strategy_mapper_callable: Callable[[], StrategyMapper]):
         self.strategy_mapper_callable = strategy_mapper_callable
 
-    def build(self, strategy: Strategy) -> PolicyStrategy[Any] | None:
+    def build(self, strategy: Strategy) -> Optional[PolicyStrategy]:
         strategy_class = self.strategy_mapper_callable().get(strategy.name)
         if not strategy_class:
             return None

--- a/py_authorization/sql_parser.py
+++ b/py_authorization/sql_parser.py
@@ -14,6 +14,7 @@ def to_class(entity):  # type: ignore
 
 
 def get_column_entity_with_attribute(statement, attribute):  # type: ignore
+
     try:
         for cd in statement.column_descriptions:
             if hasattr(cd.get("entity"), attribute):
@@ -103,7 +104,6 @@ def default_load_entities(entities):  # type: ignore
 # TODO: Still needs to be generalized & support other options.
 
 # the structure we're dealing with is essentially:
-
 
 # (path, strategy, options)
 # where "path" indicates what it is we are loading,


### PR DESCRIPTION
## Summary
- The merge of the or-strategy branch (`f28b140`) introduced unintended changes from the branch's old divergent history
- Most critically, the `_EmptyEntity` class was deleted but its usage on line 222 was not updated, causing `ImportError: cannot import name '_EmptyEntity'`
- Several formatting changes (multi-line → single-line) and a removed debug log were also reverted

## Files affected
- `py_authorization/authorization.py` — restored `_EmptyEntity` class, removed broken `EmptyEntity` import, restored formatting
- `py_authorization/__init__.py` — removed unintended `EmptyEntity` export
- `py_authorization/policy_strategy.py` — reverted to original
- `py_authorization/policy_strategy_builder.py` — reverted to original
- `py_authorization/sql_parser.py` — reverted to original

## Test plan
- [ ] Verify `from py_authorization.authorization import _EmptyEntity` no longer raises ImportError
- [ ] Run existing test suite